### PR TITLE
Date format

### DIFF
--- a/src/builtin/date_format.h
+++ b/src/builtin/date_format.h
@@ -1,10 +1,10 @@
 /**
- *  Strlen.h
+ *  date_format.h
  *
- *  Built-in "|strlen" modifier
+ *  Built-in "|date_format" modifier
  *
- *  @author Toon Schoenmakers <toon.schoenmakers@copernica.com>
- *  @copyright 2014 Copernica BV
+ *  @author Tamas Elekes <tamas.elekes@copernica.com>
+ *  @copyright 2018 Copernica BV
  */
 
 /**

--- a/src/builtin/date_format.h
+++ b/src/builtin/date_format.h
@@ -34,8 +34,8 @@ public:
      */
     VariantValue modify(const Value &input, const SmartTpl::Parameters &params) override
     {
-        // initialize our timestamp, empty string is 0 therefore current time
-        time_t timestamp(input.toNumeric());
+        // initialize our timestamp, if empty string the current time, epoch start time if invalid input
+        time_t timestamp = input.toString().empty() ? time(0) : input.toNumeric();
 
         // initialize the format
         std::string format = params.size() >= 1 ? params[0].toString() : "%b %e, %Y";

--- a/src/builtin/date_format.h
+++ b/src/builtin/date_format.h
@@ -1,0 +1,59 @@
+/**
+ *  Strlen.h
+ *
+ *  Built-in "|strlen" modifier
+ *
+ *  @author Toon Schoenmakers <toon.schoenmakers@copernica.com>
+ *  @copyright 2014 Copernica BV
+ */
+
+/**
+ *  Namespace
+ */
+
+#include <ctime>
+
+namespace SmartTpl { namespace Internal {
+
+/**
+ *  Class definition
+ */
+class DateFormatModifier : public Modifier
+{
+public:
+    /**
+     *  Destructor
+     */
+    virtual ~DateFormatModifier() {};
+
+    /**
+     *  Modify a value object
+     *  @param  input
+     *  @param  params      Parameters used for this modification
+     *  @return Value
+     */
+    VariantValue modify(const Value &input, const SmartTpl::Parameters &params) override
+    {
+        // initialize our timestamp, empty string is 0 therefore current time
+        time_t timestamp(input.toNumeric());
+
+        // initialize the format
+        std::string format = params.size() >= 1 ? params[0].toString() : "%b %e, %Y";
+
+
+        char buffer[100];
+        tm * timeinfo = localtime(&timestamp);
+
+        // creating conversion from timestamp to formatted time string
+        strftime(buffer, sizeof(buffer), format.c_str(), timeinfo);
+
+        std::string time_str(buffer);
+
+        return time_str;
+    }
+};
+
+/**
+ *  End namespace
+ */
+}}

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -11,6 +11,7 @@
  *  Dependencies
  */
 #include "includes.h"
+#include "builtin/date_format.h"
 
 /**
  *  Namespace
@@ -39,6 +40,7 @@ static Internal::RegexReplaceModifier    regex_replace;
 static Internal::SubStrModifier          substr;
 static Internal::StrPosModifier          strpos;
 static Internal::StrStrModifier          strstr;
+static Internal::DateFormatModifier      date_format;
 static Internal::UrlencodeModifier       urlencode;
 static Internal::UrldecodeModifier       urldecode;
 static Internal::Md5Modifier             md5;
@@ -77,6 +79,7 @@ Data::Data()
               {"substr",           &substr},
               {"strstr",           &strstr},
               {"strpos",           &strpos},
+              {"date_format",      &date_format},
               {"urlencode",        &urlencode},
               {"urldecode",        &urldecode},
               {"range",            &range_modifier}}) // register built-in modifiers

--- a/test/modifier.cpp
+++ b/test/modifier.cpp
@@ -276,6 +276,24 @@ TEST(Modifier, Strlen)
     }
 }
 
+TEST(Modifier, DateFormat)
+{
+    string input("{$var|date_format}\n{$var|date_format:\"%A, %B %e, %Y\"}\n{$var|date_format:\"%D\"}\n{$var|date_format}");
+    Template tpl((Buffer(input)));
+
+    Data data;
+    data.assign("var", "1533081600\n1533081600\n1533081600");
+
+    string expectedOutput("Aug  1, 2018\nWednesday, August  1, 2018\n08/01/18");
+    EXPECT_EQ(expectedOutput, tpl.process(data));
+
+    if (compile(tpl)) // This will compile the Template into a shared library
+    {
+        Template library(File(SHARED_LIBRARY)); // Here we load that shared library
+        EXPECT_EQ(expectedOutput, library.process(data));
+    }
+}
+
 TEST(Modifier, Count)
 {
     string input("{$var|count}");

--- a/test/modifier.cpp
+++ b/test/modifier.cpp
@@ -278,7 +278,7 @@ TEST(Modifier, Strlen)
 
 TEST(Modifier, DateFormat)
 {
-    string input("{$var|date_format}\n{$var|date_format:\"%A, %B %e, %Y\"}\n{$var|date_format:\"%D\"}\n{$var|date_format}");
+    string input("{$var|date_format}\n{$var|date_format:\"%A, %B %e, %Y\"}\n{$var|date_format:\"%D\"}");
     Template tpl((Buffer(input)));
 
     Data data;


### PR DESCRIPTION
 date_format modifier that formats a date and time into the given strftime() format. Dates can be passed as unix timestamps, the parameter is the string format.

Smarty reference: https://www.smarty.net/docs/en/language.modifier.date.format.tpl