### PR TITLE
number_format modifier

### DIFF
--- a/src/builtin/number_format.h
+++ b/src/builtin/number_format.h
@@ -1,0 +1,66 @@
+/**
+ *  NumberFormat.h
+ *
+ *  Built-in "|number_format" modifier
+ *
+ *  @author         David van Erkelens <david.vanerkelens@copernica.com>
+ *  @copyright      2019 Copernica BV
+ */
+
+/**
+ *  Namespace
+ */
+namespace SmartTpl { namespace Internal {
+
+/**
+ *  Class definition
+ */
+class NumberFormatModifier : public Modifier
+{
+public:
+    /**
+     *  Destructor
+     */
+    virtual ~NumberFormatModifier() {};
+
+    /**
+     *  Modify a value object
+     *  @param  input
+     *  @param  params      Parameters used for this modification
+     *  @return Value
+     */
+    VariantValue modify(const Value &input, const SmartTpl::Parameters &params) override
+    {
+        // Convert input to double
+        double original(input.toDouble());
+
+        // make sure we have a parameter containing the format
+        if (params.size() < 1) throw NoModification();
+
+        // get the amound of decimals to output
+        int decimals = params[0].toInteger();
+
+        // buffer to create the printf format
+        char format[10];
+
+        // format the format
+        sprintf(format, "%%.%if", decimals);
+
+        // calculate size of new string
+        size_t size = snprintf(nullptr, 0, format, original);
+
+        // create buffer
+        char buffer[size + 1];
+
+        // create new string
+        sprintf(buffer, format, original);
+
+        // create object
+        return VariantValue(buffer);
+    }
+};
+
+/**
+ *  End namespace
+ */
+}}

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -41,6 +41,7 @@ static Internal::RegexReplaceModifier    regex_replace;
 static Internal::SubStrModifier          substr;
 static Internal::StrPosModifier          strpos;
 static Internal::StrStrModifier          strstr;
+static Internal::NumberFormatModifier    number_format;
 static Internal::DateFormatModifier      date_format;
 static Internal::UrlencodeModifier       urlencode;
 static Internal::UrldecodeModifier       urldecode;
@@ -81,6 +82,7 @@ Data::Data()
               {"substr",           &substr},
               {"strstr",           &strstr},
               {"strpos",           &strpos},
+              {"number_format",    &number_format},
               {"date_format",      &date_format},
               {"urlencode",        &urlencode},
               {"urldecode",        &urldecode},

--- a/src/includes.h
+++ b/src/includes.h
@@ -105,6 +105,7 @@
 #include "builtin/substr.h"
 #include "builtin/strstr.h"
 #include "builtin/strpos.h"
+#include "builtin/number_format.h"
 #include "builtin/urlencode.h"
 #include "builtin/urldecode.h"
 #include "builtin/md5.h"

--- a/test/modifier.cpp
+++ b/test/modifier.cpp
@@ -340,6 +340,25 @@ TEST(Modifier, DateFormat)
     }
 }
 
+TEST(Modifier, NumberFormat)
+{
+    string input("{$var1|number_format}\n{$var1|number_format:0}\n{$var1|number_format:1}\n{$var1|number_format:4}");
+    Template tpl((Buffer(input)));
+
+    Data data;
+    data.assign("var1", "123.45");
+
+    string expectedOutput("123.45\n123\n123.5\n123.4500");
+
+    EXPECT_EQ(expectedOutput, tpl.process(data));
+
+    if (compile(tpl)) // This will compile the Template into a shared library
+    {
+        Template library(File(SHARED_LIBRARY)); // Here we load that shared library
+        EXPECT_EQ(expectedOutput, library.process(data));
+    }
+}
+
 TEST(Modifier, Count)
 {
     string input("{$var|count}");


### PR DESCRIPTION
This branch adds the `number_format` modifier to SMART-TPL, to allow the precision to be set when printing floating point numbers.