### PR TITLE
Add locale-independent float parsing

### DIFF
--- a/include/doublevalue.h
+++ b/include/doublevalue.h
@@ -62,7 +62,7 @@ public:
         while (buffer[written - 1] == '0') written--;
 
         // Round number?
-        if (buffer[written - 1] == '.') written--;
+        if (buffer[written - 1] == '.' || buffer[written - 1] == ',') written--;
 
         // Create string object
         return std::string(buffer, written);

--- a/src/doubleparser.h
+++ b/src/doubleparser.h
@@ -1,0 +1,69 @@
+/**
+ *  DoubleParser.h
+ * 
+ *  Helper class that is capable of parsing dot-based double values, no matter
+ *  the current locale of the system SMART-TPL is running on. This is to ensure
+ *  that floating point numbers are always parsed correctly.
+ * 
+ *  @author         David van Erkelens <david.vanerkelens@copernica.com>
+ *  @copyright      2019 Copernica BV
+ */
+
+/**
+ *  Dependencies
+ */
+#include <locale>
+
+/**
+ *  Set up namespace
+ */
+namespace SmartTpl { namespace Internal {
+
+/**
+ *  Class definition
+ */
+class DoubleParser {
+private:
+    /**
+     *  The parsed value
+     *  @var double
+     */
+    double _value;
+
+public:
+    /**
+     *  Constructor
+     *  @param  const char *
+     */
+    DoubleParser(const char *buffer)
+    {
+        // The current system we're running on might be set to another locale, 
+        // which has comma separators instead of dots. To ensure correct
+        // parsing of the floating point number, we temporarily reset the locale
+        // First, get the current locale setting
+        auto current = setlocale(LC_NUMERIC, NULL);
+
+        // force en_US locale for numeric values
+        setlocale(LC_NUMERIC, "en_US");
+
+        // parse the token
+        _value = std::strtod(buffer, nullptr);
+
+        // reset locale
+        setlocale(LC_NUMERIC, current);
+    }
+
+    /**
+     *  Cast to double
+     *  @return double
+     */
+    operator double() const 
+    {
+        return _value;
+    }
+};
+
+/**
+ *  End of namespace
+ */
+}}

--- a/src/doubleparser.h
+++ b/src/doubleparser.h
@@ -5,6 +5,13 @@
  *  the current locale of the system SMART-TPL is running on. This is to ensure
  *  that floating point numbers are always parsed correctly - that being according
  *  to the SMART-TPL defintion (1.0) instead of the current locale (1.0 or 1,0).
+ *  Therefore, this class is basically a locale-independent variant of the 
+ *  default strtod function.
+ * 
+ *  This parser uses a istringstream with a locale setting, since we don't want to
+ *  change the global locale due to possible undefined behaviours in multithreaded
+ *  applications. Therefore, a locale setting is applied to the stream only, so
+ *  parsing doubles does not interfere with other threads.
  * 
  *  @author         David van Erkelens <david.vanerkelens@copernica.com>
  *  @copyright      2019 Copernica BV

--- a/src/doubleparser.h
+++ b/src/doubleparser.h
@@ -14,6 +14,7 @@
  *  Dependencies
  */
 #include <locale>
+#include <sstream>
 
 /**
  *  Set up namespace
@@ -38,21 +39,14 @@ public:
      */
     DoubleParser(const char *buffer)
     {
-        // The current system we're running on might be set to another locale, 
-        // which has comma separators instead of dots. To ensure correct
-        // parsing of the floating point number, we temporarily reset the locale
-        // First, get the current locale setting. We store this in a string copy,
-        // since the buffer might turn into garbage when changing the locale
-        std::string current(std::setlocale(LC_NUMERIC, NULL));
+        // create stream based on the buffer
+        std::istringstream stream(buffer);
 
-        // force en_US locale for numeric values
-        std::setlocale(LC_NUMERIC, "en_US");
+        // set stream locale
+        stream.imbue(std::locale("en_US"));
 
-        // parse the token
-        _value = std::strtod(buffer, nullptr);
-
-        // reset locale
-        std::setlocale(LC_NUMERIC, current.data());
+        // stream to the value
+        stream >> _value;
     }
 
     /**

--- a/src/doubleparser.h
+++ b/src/doubleparser.h
@@ -41,17 +41,18 @@ public:
         // The current system we're running on might be set to another locale, 
         // which has comma separators instead of dots. To ensure correct
         // parsing of the floating point number, we temporarily reset the locale
-        // First, get the current locale setting
-        auto current = setlocale(LC_NUMERIC, NULL);
+        // First, get the current locale setting. We store this in a string copy,
+        // since the buffer might turn into garbage when changing the locale
+        std::string current(std::setlocale(LC_NUMERIC, NULL));
 
         // force en_US locale for numeric values
-        setlocale(LC_NUMERIC, "en_US");
+        std::setlocale(LC_NUMERIC, "en_US");
 
         // parse the token
         _value = std::strtod(buffer, nullptr);
 
         // reset locale
-        setlocale(LC_NUMERIC, current);
+        std::setlocale(LC_NUMERIC, current.data());
     }
 
     /**

--- a/src/doubleparser.h
+++ b/src/doubleparser.h
@@ -3,7 +3,8 @@
  * 
  *  Helper class that is capable of parsing dot-based double values, no matter
  *  the current locale of the system SMART-TPL is running on. This is to ensure
- *  that floating point numbers are always parsed correctly.
+ *  that floating point numbers are always parsed correctly - that being according
+ *  to the SMART-TPL defintion (1.0) instead of the current locale (1.0 or 1,0).
  * 
  *  @author         David van Erkelens <david.vanerkelens@copernica.com>
  *  @copyright      2019 Copernica BV

--- a/src/expressions/literaldouble.h
+++ b/src/expressions/literaldouble.h
@@ -22,7 +22,7 @@ private:
      *  The actual value
      *  @var    double
      */
-    double _value;
+    const double _value;
 
     /**
      *  The provided string representation of the literal

--- a/src/expressions/literaldouble.h
+++ b/src/expressions/literaldouble.h
@@ -8,11 +8,6 @@
  */
 
 /**
- *  Dependencies
- */
-#include <locale>
-
-/**
  *  Namespace
  */
 namespace SmartTpl { namespace Internal {
@@ -40,23 +35,7 @@ public:
      *  Constructor
      *  @param  token
      */
-    LiteralDouble(Token *token): _token(token) 
-    {
-        // The current system we're running on might be set to another locale, 
-        // which has comma separators instead of dots. To ensure correct
-        // parsing of the floating point number, we temporarily reset the locale
-        // First, get the current locale setting
-        auto current = setlocale(LC_NUMERIC, NULL);
-
-        // force en_US locale for numeric values
-        setlocale(LC_NUMERIC, "en_US");
-
-        // parse the token
-        _value = std::strtod(token->c_str(), nullptr);
-
-        // reset locale
-        setlocale(LC_NUMERIC, current);
-    }
+    LiteralDouble(Token *token): _value(DoubleParser(token->data())), _token(token) {}
 
     /**
      *  Destructor

--- a/src/expressions/literaldouble.h
+++ b/src/expressions/literaldouble.h
@@ -8,6 +8,11 @@
  */
 
 /**
+ *  Dependencies
+ */
+#include <locale>
+
+/**
  *  Namespace
  */
 namespace SmartTpl { namespace Internal {
@@ -22,7 +27,7 @@ private:
      *  The actual value
      *  @var    double
      */
-    const double _value;
+    double _value;
 
     /**
      *  The provided string representation of the literal
@@ -35,8 +40,23 @@ public:
      *  Constructor
      *  @param  token
      */
-    LiteralDouble(Token *token)
-    : _value(std::strtod(token->c_str(), nullptr)), _token(token) {}
+    LiteralDouble(Token *token): _token(token) 
+    {
+        // The current system we're running on might be set to another locale, 
+        // which has comma separators instead of dots. To ensure correct
+        // parsing of the floating point number, we temporarily reset the locale
+        // First, get the current locale setting
+        auto current = setlocale(LC_NUMERIC, NULL);
+
+        // force en_US locale for numeric values
+        setlocale(LC_NUMERIC, "en_US");
+
+        // parse the token
+        _value = std::strtod(token->c_str(), nullptr);
+
+        // reset locale
+        setlocale(LC_NUMERIC, current);
+    }
 
     /**
      *  Destructor

--- a/src/handler.h
+++ b/src/handler.h
@@ -174,7 +174,7 @@ public:
         while (buffer[written - 1] == '0') written--;
 
         // Round number?
-        if (buffer[written - 1] == '.') written--;
+        if (buffer[written - 1] == '.' || buffer[written - 1] == ',') written--;
 
         // Add to total buffer
         _buffer.append(buffer, written);

--- a/src/includes.h
+++ b/src/includes.h
@@ -78,6 +78,7 @@
 #include "generator.h"
 #include "escaper.h"
 #include "callbackvalue.h"
+#include "doubleparser.h"
 #include "dynamic/openssl.h"
 #include "escapers/null.h"
 #include "escapers/html.h"

--- a/test/runtime.cpp
+++ b/test/runtime.cpp
@@ -833,3 +833,55 @@ TEST(RunTime, IfWithModifierNumberComparison)
         EXPECT_EQ(expectedOutput2, library.process(data2));
     }
 }
+
+TEST(RunTime, LocaleIndependentDoubleParsing)
+{
+    string input("{$a = 1.23}{$a}");
+
+    string expectedOutput_en_US("1.23");
+    string expectedOutput_nl_NL("1,23");
+
+    // save locale
+    std::string current(setlocale(LC_NUMERIC, NULL));
+
+    // set en_US locale
+    setlocale(LC_NUMERIC, "en_US");
+
+    // format template
+    Template tpl1((Buffer(input)));
+    EXPECT_TRUE(tpl1.personalized());
+
+    // check en_US
+    EXPECT_EQ(expectedOutput_en_US, tpl1.process());
+
+    if (compile(tpl1)) // This will compile the Template into a shared library
+    {
+        Template library(File(SHARED_LIBRARY)); // Here we load that shared library
+        EXPECT_TRUE(library.personalized());
+
+        // check en_US
+        EXPECT_EQ(expectedOutput_en_US, library.process());
+    }
+
+    // set nl_NL locale
+    setlocale(LC_NUMERIC, "nl_NL");
+
+    // format template
+    Template tpl2((Buffer(input)));
+    EXPECT_TRUE(tpl2.personalized());
+
+    // check nl_NL
+    EXPECT_EQ(expectedOutput_nl_NL, tpl2.process());
+
+    if (compile(tpl2)) // This will compile the Template into a shared library
+    {
+        Template library(File(SHARED_LIBRARY)); // Here we load that shared library
+        EXPECT_TRUE(library.personalized());
+
+        // check nl_NL
+        EXPECT_EQ(expectedOutput_nl_NL, library.process());
+    }
+
+    // reset locale
+    setlocale(LC_NUMERIC, current.data());
+}


### PR DESCRIPTION
Currently, SMART-TPL supports doubles / floats to be defined in a template like `{$a = 1.23}`. The expression (`1.23`) is then parsed by the `std::strtod` function to create a double when parsing the template. However, `std::strtod` is locale-dependent, therefore the parsing operation will return `1` when the current system (or process) locale uses a comma as decimal separator (e.g. `nl_NL` or `tr_TR`). This pull request deals with the parsing of doubles by introducing a locale-independent double parser, which always is able to parse dot-separated floating point numbers (which are the only ones supported by the tokenizer).