### PR TITLE
Extend number format

### DIFF
--- a/src/builtin/number_format.h
+++ b/src/builtin/number_format.h
@@ -27,8 +27,8 @@ private:
      *  Struct that works with the std::numpunct facet and can be
      *  constructed with a char for the decimal and thousands separators 
      */
-    struct formatter : std::numpunct<char> {
-
+    struct formatter : std::numpunct<char>
+    {
         // chars for the separators
         char decimal; char thousand;
 

--- a/src/builtin/number_format.h
+++ b/src/builtin/number_format.h
@@ -61,9 +61,28 @@ public:
         // get the amount of decimals to output
         int decimals = params[0].toInteger();
 
-        // get separators for decimals and thousands
-        char decimal_separator = params.size() > 1 ? params[1].toString()[0] : '.';
-        char thousand_separator = params.size() > 2 ? params[2].toString()[0] : (char) 0;
+        // get separator variables for decimals and thousands
+        char decimal_separator = '.'; char thousand_separator = (char) 0;
+
+        // if we have a valid parameter, overwrite decimal separator
+        if (params.size() > 1)
+        {
+            // convert to string
+            auto param = params[1].toString();
+
+            // make sure that we have a character (we could throw if the param is too long?)
+            if (param.size() > 0) decimal_separator = param[0]; 
+        }
+
+        // if we have a valid parameter, overwrite thousands separator
+        if (params.size() > 2)
+        {
+            // convert to string
+            auto param = params[2].toString();
+
+            // make sure that we have a character (we could throw if the param is too long?)
+            if (param.size() > 0) thousand_separator = param[0]; 
+        }
 
         // create stringstream to store formatted number
         std::stringstream stream;

--- a/src/builtin/number_format.h
+++ b/src/builtin/number_format.h
@@ -4,7 +4,7 @@
  *  Built-in "|number_format" modifier
  *
  *  @author         David van Erkelens <david.vanerkelens@copernica.com>
- *  @copyright      2019 Copernica BV
+ *  @copyright      2019 - 2020 Copernica BV
  */
 
 /**

--- a/test/modifier.cpp
+++ b/test/modifier.cpp
@@ -359,6 +359,25 @@ TEST(Modifier, NumberFormat)
     }
 }
 
+TEST(Modifier, NumberFormatWithSeparators)
+{
+    string input("{$var1|number_format:2:'.':','}\n{$var1|number_format:2:',':'|'}\n{$var1|number_format:0:'.':','}\n{$var1|number_format:2:'x'}");
+    Template tpl((Buffer(input)));
+
+    Data data;
+    data.assign("var1", "123123.45");
+
+    string expectedOutput("123,123.45\n123|123,45\n123,123\n123123x45");
+
+    EXPECT_EQ(expectedOutput, tpl.process(data));
+
+    if (compile(tpl)) // This will compile the Template into a shared library
+    {
+        Template library(File(SHARED_LIBRARY)); // Here we load that shared library
+        EXPECT_EQ(expectedOutput, library.process(data));
+    }
+}
+
 TEST(Modifier, Count)
 {
     string input("{$var|count}");


### PR DESCRIPTION
Currently, we do not support custom decimal and thousands separators for the `number_format` modifier. This project adds support for those separators, so the following becomes possible:

```
{$a = 12345.67}
{$a|number_format:2:',':'.'}
```

Which will output `12.345,67`.