### PR TITLE
now uses refs instead of copy

### DIFF
--- a/src/escapers/json.h
+++ b/src/escapers/json.h
@@ -71,7 +71,7 @@ public:
         output.reserve(input.size());
 
         // iterate over the characters
-        for (const uint8_t &c : input)
+        for (const char &c : input)
         {
             // in the first 32 bits we always have to escape
             if (c < 32 || c == '"' || c == '\\')


### PR DESCRIPTION
When compiling on jammy, u get alot of warnings and notes:

```
In file included from src/includes.h:86,
                 from src/parser.lemon:41:
src/escapers/json.h: In member function 'virtual std::string& SmartTpl::Internal::JsonEscaper::encode(std::string&) const':
src/escapers/json.h:74:29: warning: loop variable 'c' of type 'const uint8_t&' {aka 'const unsigned char&'} binds to a temporary constructed from type 'char' [-Wrange-loop-construct]
   74 |         for (const uint8_t &c : input)
      |                             ^
src/escapers/json.h:74:29: note: use non-reference type 'const uint8_t' {aka 'const unsigned char'} to make the copy explicit or 'const char&' to prevent copying
g++ -Wall -c -I. -O2 -MD -pipe -std=c++11 -Wno-sign-compare -Wno-psabi -fPIC -o src/template.o src/template.cpp
In file included from src/includes.h:86,
                 from src/template.cpp:9:

```
This changes removes these warnings, and removes copying